### PR TITLE
Fix zoom issues

### DIFF
--- a/NovaCamera/Base.lproj/Main_iPhone.storyboard
+++ b/NovaCamera/Base.lproj/Main_iPhone.storyboard
@@ -31,10 +31,17 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6ig-CU-Xix" customClass="SSCameraPreviewView">
+                            <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gOP-u3-1pE" userLabel="Preview Holder">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6ig-CU-Xix" customClass="SSCameraPreviewView">
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             </view>
                             <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Si-W3-Mqg" customClass="SSPassThroughView">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
@@ -158,16 +165,19 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="6ig-CU-Xix" firstAttribute="top" secondItem="jDK-1B-82m" secondAttribute="bottom" id="2z9-ZF-fvn"/>
-                            <constraint firstItem="R1q-RJ-5fu" firstAttribute="top" secondItem="6ig-CU-Xix" secondAttribute="bottom" id="5Wh-pg-hcl"/>
+                            <constraint firstAttribute="trailing" secondItem="gOP-u3-1pE" secondAttribute="trailing" id="7e5-U5-cLR"/>
                             <constraint firstItem="2Si-W3-Mqg" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="9om-8H-VTA"/>
+                            <constraint firstItem="gOP-u3-1pE" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="AZW-gh-rnO"/>
+                            <constraint firstItem="gOP-u3-1pE" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="NU0-PW-d5m"/>
+                            <constraint firstAttribute="bottom" secondItem="gOP-u3-1pE" secondAttribute="bottom" id="NgL-vs-kR9"/>
                             <constraint firstAttribute="bottom" secondItem="2Si-W3-Mqg" secondAttribute="bottom" id="URU-JJ-iFY"/>
-                            <constraint firstItem="6ig-CU-Xix" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="idS-gh-ofS"/>
-                            <constraint firstAttribute="trailing" secondItem="6ig-CU-Xix" secondAttribute="trailing" id="ikp-aH-wEc"/>
+                            <constraint firstAttribute="trailing" secondItem="gOP-u3-1pE" secondAttribute="trailing" id="bnD-s8-j5g"/>
                             <constraint firstItem="2Si-W3-Mqg" firstAttribute="top" secondItem="kh9-bI-dsS" secondAttribute="top" id="jcX-ZS-AnB"/>
+                            <constraint firstItem="R1q-RJ-5fu" firstAttribute="top" secondItem="gOP-u3-1pE" secondAttribute="bottom" id="ltg-ww-C3L"/>
                             <constraint firstAttribute="trailing" secondItem="2Si-W3-Mqg" secondAttribute="trailing" id="s9L-iu-SDl"/>
+                            <constraint firstItem="gOP-u3-1pE" firstAttribute="top" secondItem="jDK-1B-82m" secondAttribute="bottom" id="wNx-4E-c3g"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="wUf-kX-Qgc"/>

--- a/NovaCamera/ViewControllers/SSCameraViewController.m
+++ b/NovaCamera/ViewControllers/SSCameraViewController.m
@@ -42,6 +42,10 @@ static const NSTimeInterval kZoomSliderAnimationDuration = 0.25;
     // Zoom slider state
     BOOL _zoomSliderVisible;
     CFTimeInterval _zoomActiveTimestamp;
+    
+    // Temporary storage for zoom data
+    CGFloat _previousScaleAndCropFactor;
+    CGFloat _previousZoomSliderValue;
 }
 @property (nonatomic, strong) SSCaptureSessionManager *captureSessionManager;
 @property (nonatomic, strong) AVAudioPlayer *captureButtonAudioPlayer;
@@ -56,6 +60,8 @@ static const NSTimeInterval kZoomSliderAnimationDuration = 0.25;
 - (void)setupZoomSlider;
 - (void)zoomActive;
 - (void)zoomCheckActivityAndClose;
+- (void)saveAndResetZoom;
+- (void)restoreOrResetZoom;
 @end
 
 @implementation SSCameraViewController
@@ -88,6 +94,8 @@ static const NSTimeInterval kZoomSliderAnimationDuration = 0.25;
     
     // Setup preview layer
     self.previewView.session = self.captureSessionManager.session;
+    //self.previewView.layer.anchorPoint = CGPointMake(self.previewView.bounds.size.width / 2, self.previewView.bounds.size.height / 2);
+    self.previewView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     
     // Add flash service
     self.flashService = [SSNovaFlashService sharedService];
@@ -138,7 +146,10 @@ static const NSTimeInterval kZoomSliderAnimationDuration = 0.25;
     [self setupCaptureButtonAudioPlayer];
    
     // Reset zoom
-    [self resetZoom];
+    [self restoreOrResetZoom];
+    
+    // Manually ensure preview view is full-screen
+    self.previewView.frame = self.view.bounds;
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -154,6 +165,13 @@ static const NSTimeInterval kZoomSliderAnimationDuration = 0.25;
     [self.captureSessionManager removeObserver:self forKeyPath:@"sessionRunningAndDeviceAuthorized" context:SessionRunningAndDeviceAuthorizedContext];
     [self.flashService removeObserver:self forKeyPath:@"status"];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"AVSystemController_SystemVolumeDidChangeNotification" object:nil];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    
+    // Store zoom information and reset before disappearing
+    [self saveAndResetZoom];
 }
 
 - (void)didReceiveMemoryWarning
@@ -182,6 +200,18 @@ static const NSTimeInterval kZoomSliderAnimationDuration = 0.25;
     } else {
         DDLogVerbose(@"Got unknown segue %@", segue.identifier);
     }
+}
+
+
+// Rotation; reset preview layer prior to rotation and restore after
+- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
+    [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
+    [self saveAndResetZoom];
+}
+
+- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
+    [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
+    [self restoreOrResetZoom];
 }
 
 #pragma mark - KVO
@@ -515,6 +545,23 @@ static const NSTimeInterval kZoomSliderAnimationDuration = 0.25;
             });
         }
     }
+}
+
+- (void)saveAndResetZoom {
+    _previousScaleAndCropFactor = self.scaleAndCropFactor;
+    _previousZoomSliderValue = self.zoomSlider.value;
+    [self resetZoom];
+    self.previewView.center = self.view.center;
+}
+
+- (void)restoreOrResetZoom {
+    if (_previousScaleAndCropFactor > 0.01) {
+        self.scaleAndCropFactor = _previousScaleAndCropFactor;
+        self.zoomSlider.value = _previousZoomSliderValue;
+    } else {
+        [self resetZoom];
+    }
+    self.previewView.center = self.view.center;
 }
 
 #pragma mark - SSFlashSettingsViewControllerDelegate

--- a/NovaCamera/Views/SSCameraPreviewView.m
+++ b/NovaCamera/Views/SSCameraPreviewView.m
@@ -46,6 +46,11 @@
     return [AVCaptureVideoPreviewLayer class];
 }
 
+// Don't use autolayout
+- (BOOL)translatesAutoresizingMaskIntoConstraints {
+    return YES;
+}
+
 - (AVCaptureSession *)session {
     AVCaptureVideoPreviewLayer *layer = (AVCaptureVideoPreviewLayer *)self.layer;
     return layer.session;


### PR DESCRIPTION
Avoid using auto layout for AVCaptureVideoPreviewLayer which uses layer transitions
for zoom effect. Instead use a container view with auto layout and use auto resize
mask for preview view.

Reset zoom level before changing screens and rotating device. Restore zoom level
when view is displayed again or rotation has completed.

Fixes #93 
